### PR TITLE
Made certbot-kong compatible with certbot v1.0.0

### DIFF
--- a/certbot_kong/configurator.py
+++ b/certbot_kong/configurator.py
@@ -7,7 +7,7 @@ import zope.interface
 
 from acme import challenges
 
-import certbot.constants
+import certbot._internals.constants
 from certbot import errors
 from certbot import interfaces
 from certbot import util


### PR DESCRIPTION
Fixed import for making it compatible with certbot v1.0.0

They changed some modules from `certbot` to `certbot._internals`.